### PR TITLE
Run pre-commit hooks in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,13 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+
+ci:
+  autofix_prs: true
+  autofix_commit_msg: "chore: auto fixes from pre-commit hooks"
+  autoupdate_commit_msg: "chore(deps): pre-commit autoupdate"
+  skip:
+    - typos
+    - fmt
+    - cargo-check
+    - clippy


### PR DESCRIPTION
Allows to use pre-commit.ci to auto update PRs and hook versions.

Closes #16 